### PR TITLE
feat: Display commune map on homepage

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { MapContainer, TileLayer, GeoJSON } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import { useEffect, useState } from 'react';
+import { LatLngExpression } from 'leaflet';
+
+const Map = () => {
+  const [geoJsonData, setGeoJsonData] = useState(null);
+
+  useEffect(() => {
+    // Fetch the GeoJSON data from the public folder
+    fetch('/data/haux-boundary.geojson')
+      .then((response) => response.json())
+      .then((data) => {
+        setGeoJsonData(data);
+      });
+  }, []);
+
+  const center: LatLngExpression = [44.75, -0.38]; // Center on Haux
+
+  return (
+    <MapContainer center={center} zoom={13} style={{ height: '100%', width: '100%' }}>
+      <TileLayer
+        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+      />
+      {geoJsonData && (
+        <GeoJSON
+          data={geoJsonData}
+          style={() => ({
+            color: '#4a83ec',
+            weight: 2,
+            fillColor: "#1a1d62",
+            fillOpacity: 0.2,
+          })}
+        />
+      )}
+    </MapContainer>
+  );
+};
+
+export default Map;

--- a/app/components/MapLoader.tsx
+++ b/app/components/MapLoader.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import dynamic from 'next/dynamic';
+import { useMemo } from 'react';
+
+const MapLoader = () => {
+  const Map = useMemo(() => dynamic(
+    () => import('@/app/components/Map'),
+    {
+      loading: () => <p>A map is loading</p>,
+      ssr: false
+    }
+  ), []);
+
+  return <Map />;
+};
+
+export default MapLoader;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,16 @@
 import LoginButton from "./components/LoginButton";
+import MapLoader from "./components/MapLoader";
 
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center p-24">
-      <h1 className="text-4xl font-bold mb-8">Haux Road Network App</h1>
-      <LoginButton />
+    <main className="flex min-h-screen flex-col items-center">
+      <div className="w-full p-4 flex justify-between items-center bg-gray-100 shadow-md">
+        <h1 className="text-2xl font-bold">Haux Road Network App</h1>
+        <LoginButton />
+      </div>
+      <div className="w-full h-[calc(100vh-80px)]">
+        <MapLoader />
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
This commit introduces an interactive map to the homepage, centered on the commune of Haux and displaying its geographical boundary.

- Creates a `Map` component to render the Leaflet map.
- Implements dynamic loading for the `Map` component within a new `MapLoader` client component to prevent SSR issues with Next.js App Router.
- Updates the homepage to use the `MapLoader`, displaying the map below the header.