### PR TITLE
feat: Implement Leaflet-based notifications

### DIFF
--- a/app/[locale]/components/MapNotification.css
+++ b/app/[locale]/components/MapNotification.css
@@ -1,0 +1,44 @@
+.leaflet-notification-container {
+  background-color: white;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 10px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  max-width: 300px;
+  z-index: 1001; /* Ensure it's above other map elements */
+}
+
+.leaflet-notification-container.success {
+  border-left: 5px solid #4CAF50; /* Green for success */
+}
+
+.leaflet-notification-container.error {
+  border-left: 5px solid #f44336; /* Red for error */
+}
+
+.leaflet-notification-container.info {
+  border-left: 5px solid #2196F3; /* Blue for info */
+}
+
+.leaflet-notification-title {
+  font-weight: bold;
+  margin: 0 0 5px 0;
+  font-size: 16px;
+}
+
+.leaflet-notification-description {
+  margin: 0;
+  font-size: 14px;
+}
+
+.leaflet-notification-close {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: none;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+  padding: 0;
+  line-height: 1;
+}

--- a/app/[locale]/components/MapNotification.tsx
+++ b/app/[locale]/components/MapNotification.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { useMap } from 'react-leaflet';
+import L from 'leaflet';
+import './MapNotification.css';
+
+interface MapNotificationProps {
+  message: {
+    title: string;
+    description: string;
+    type: 'success' | 'error' | 'info';
+  } | null;
+  onClose: () => void;
+}
+
+const MapNotification = ({ message, onClose }: MapNotificationProps) => {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!message) {
+      return;
+    }
+
+    const customControl = new (L.Control.extend({
+      onAdd: function () {
+        const container = L.DomUtil.create('div', `leaflet-notification-container ${message.type}`);
+
+        const titleElement = L.DomUtil.create('h3', 'leaflet-notification-title', container);
+        titleElement.innerText = message.title;
+
+        const descriptionElement = L.DomUtil.create('p', 'leaflet-notification-description', container);
+        descriptionElement.innerText = message.description;
+
+        const closeButton = L.DomUtil.create('button', 'leaflet-notification-close', container);
+        closeButton.innerHTML = '&times;';
+        closeButton.onclick = () => {
+          onClose();
+        };
+
+        // Disable map interactions when interacting with the notification
+        L.DomEvent.disableClickPropagation(container);
+        L.DomEvent.disableScrollPropagation(container);
+
+        return container;
+      },
+
+      onRemove: function () {
+        // Cleanup
+      },
+    }))({ position: 'topright' });
+
+    map.addControl(customControl);
+
+    const timer = setTimeout(() => {
+      onClose();
+    }, 5000); // Auto-dismiss after 5 seconds
+
+    return () => {
+      clearTimeout(timer);
+      map.removeControl(customControl);
+    };
+  }, [map, message, onClose]);
+
+  return null;
+};
+
+export default MapNotification;

--- a/messages/en.json
+++ b/messages/en.json
@@ -7,8 +7,9 @@
     "signOutButton": "Sign out"
   },
   "Map": {
+    "loginRequiredTitle": "Login Required",
     "loginToReport": "Please log in to report an issue.",
-    "reportSubmitted": "Thank you! Your report has been submitted for review.",
+    "reportSubmitted": "Thank you! Your report has been submitted and is pending review by an administrator.",
     "geolocationErrorTitle": "Geolocation Error",
     "geolocationErrorDescription": "Could not retrieve your location. Please ensure you have granted permission and location services are enabled."
   },
@@ -21,7 +22,9 @@
     "severityPlaceholder": "Select a severity level",
     "submitButton": "Submit Report",
     "submittingButton": "Submitting...",
-    "cancelButton": "Cancel"
+    "cancelButton": "Cancel",
+    "bannedUserTitle": "Account Suspended",
+    "bannedUserDescription": "Your account has been suspended. Please contact an administrator for assistance."
   },
   "AdminDashboard": {
     "pageTitle": "Admin Dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -7,8 +7,9 @@
     "signOutButton": "Se déconnecter"
   },
   "Map": {
+    "loginRequiredTitle": "Connexion Requise",
     "loginToReport": "Veuillez vous connecter pour signaler un problème.",
-    "reportSubmitted": "Merci ! Votre signalement a été soumis pour examen.",
+    "reportSubmitted": "Merci ! Votre signalement a été soumis et est en attente d'examen par un administrateur.",
     "geolocationErrorTitle": "Erreur de Géolocalisation",
     "geolocationErrorDescription": "Impossible de récupérer votre position. Veuillez vous assurer d'avoir accordé la permission et que les services de localisation sont activés."
   },
@@ -21,7 +22,9 @@
     "severityPlaceholder": "Sélectionnez un niveau de gravité",
     "submitButton": "Envoyer le Signalement",
     "submittingButton": "Envoi en cours...",
-    "cancelButton": "Annuler"
+    "cancelButton": "Annuler",
+    "bannedUserTitle": "Compte Suspendu",
+    "bannedUserDescription": "Votre compte a été suspendu. Veuillez contacter un administrateur pour obtenir de l'aide."
   },
   "AdminDashboard": {
     "pageTitle": "Tableau de Bord Admin",


### PR DESCRIPTION
This commit replaces the previous toast notification system with a new, custom Leaflet component called `MapNotification`. This ensures that all user feedback related to map actions (e.g., login required, report submitted, banned user error) is displayed directly on the map, making it consistently visible and avoiding any CSS conflicts.

The new `MapNotification` component is a custom Leaflet control that is managed by state within the `Map.tsx` component. It includes features like auto-dismissal and a manual close button. The `ReportForm` has also been updated to communicate errors back to the `Map` component to be displayed by the new notification system.

This change also includes the fix for the blinking map markers, which was implemented by memoizing the marker components.