### PR TITLE
feat: Refine user roles and reporting interaction

### DIFF
--- a/prisma/migrations/20251104180301_add_visitor_enum/migration.sql
+++ b/prisma/migrations/20251104180301_add_visitor_enum/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "Role" ADD VALUE 'VISITOR';

--- a/prisma/migrations/20251104180315_set_visitor_default/migration.sql
+++ b/prisma/migrations/20251104180315_set_visitor_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "role" SET DEFAULT 'VISITOR';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ datasource db {
 
 // ENUMERATIONS
 enum Role {
+  VISITOR
   CITIZEN
   ADMIN
 }
@@ -52,7 +53,7 @@ model User {
   emailVerified DateTime?
   image   String?
 
-  role    Role      @default(CITIZEN)
+  role    Role      @default(VISITOR)
   status  UserStatus @default(ACTIVE)
 
   reports Report[]  // A user can have many reports


### PR DESCRIPTION
- Adds a `VISITOR` role to the `User` model and sets it as the default for new users.
- Implements a rate limit for the `VISITOR` role, allowing a maximum of 10 reports per 24 hours.
- Adds a promotion mechanism to automatically upgrade a `VISITOR` to a `CITIZEN` after they have 100 approved reports.
- Changes the map interaction for creating a report back to single-click, reverting a previous change to double-click based on user feedback.