### PR TITLE
Fix Logo Not Displaying in Feedback Emails

### DIFF
--- a/emails/ReportApprovedEmail.tsx
+++ b/emails/ReportApprovedEmail.tsx
@@ -16,7 +16,7 @@ interface ReportApprovedEmailProps {
   unsubscribeUrl: string;
 }
 
-const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
 
 export const ReportApprovedEmail = ({
   reportId,
@@ -28,7 +28,7 @@ export const ReportApprovedEmail = ({
     <Body style={main}>
       <Container style={container}>
         <Img
-          src={`${baseUrl}/_next/image?url=%2Flogo.png&w=48&q=75`}
+          src={`${baseUrl}/logo.png`}
           width="48"
           height="48"
           alt="Haux Alerte Logo"

--- a/emails/ReportRejectedEmail.tsx
+++ b/emails/ReportRejectedEmail.tsx
@@ -17,7 +17,7 @@ interface ReportRejectedEmailProps {
   unsubscribeUrl: string;
 }
 
-const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
 
 export const ReportRejectedEmail = ({
   reportId,
@@ -30,7 +30,7 @@ export const ReportRejectedEmail = ({
     <Body style={main}>
       <Container style={container}>
         <Img
-          src={`${baseUrl}/_next/image?url=%2Flogo.png&w=48&q=75`}
+          src={`${baseUrl}/logo.png`}
           width="48"
           height="48"
           alt="Haux Alerte Logo"

--- a/emails/ReportResolvedEmail.tsx
+++ b/emails/ReportResolvedEmail.tsx
@@ -16,7 +16,7 @@ interface ReportResolvedEmailProps {
   unsubscribeUrl: string;
 }
 
-const baseUrl = process.env.NEXTAUTH_URL || "http://localhost:3000";
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:3000";
 
 export const ReportResolvedEmail = ({
   reportId,
@@ -28,7 +28,7 @@ export const ReportResolvedEmail = ({
     <Body style={main}>
       <Container style={container}>
         <Img
-          src={`${baseUrl}/_next/image?url=%2Flogo.png&w=48&q=75`}
+          src={`${baseUrl}/logo.png`}
           width="48"
           height="48"
           alt="Haux Alerte Logo"


### PR DESCRIPTION
This PR fixes the broken logo image in user-facing feedback emails (approval, rejection, and resolution). 

The fix involves two changes in each of the three email templates:
1. Replacing `process.env.NEXTAUTH_URL` with `process.env.NEXT_PUBLIC_BASE_URL` as the source for the base URL. This ensures that the literal string `${VERCEL_URL}` (which Vercel does not interpolate into environment variables) does not appear in the final HTML.
2. Updating the image `src` to point directly to `/logo.png` instead of the Next.js optimization proxy (`/_next/image?...`), as email clients require stable, direct asset URLs.

Fixes #83

---
*PR created automatically by Jules for task [17477851042657572803](https://jules.google.com/task/17477851042657572803) started by @guillot-jpm*