### PR TITLE
Fix Unsubscribe Link Path mismatch

### DIFF
--- a/app/api/admin/reports/[reportId]/route.ts
+++ b/app/api/admin/reports/[reportId]/route.ts
@@ -93,7 +93,7 @@ export async function PATCH(
         request.headers.get("origin") ||
         process.env.NEXTAUTH_URL ||
         "http://localhost:3000";
-      const unsubscribeUrl = `${origin}/unsubscribe?userId=${author.id}&locale=fr`;
+      const unsubscribeUrl = `${origin}/api/unsubscribe?userId=${author.id}&locale=fr`;
 
       const rejectionReasonTranslations: { [key: string]: string } = {
         DUPLICATE: "Doublon",


### PR DESCRIPTION
The unsubscribe link in feedback emails was pointing to `/unsubscribe?userId=...&locale=fr`. Because this path does not start with `/api`, it was caught by the `next-intl` middleware and redirected to `/fr/unsubscribe`, which is a static success page. This meant the database update logic in `app/api/unsubscribe/route.ts` was never reached.

I modified `app/api/admin/reports/[reportId]/route.ts` to change the link to `/api/unsubscribe?userId=...&locale=fr`. Since `/api` is excluded from the middleware matcher, the request now correctly reaches the API route, updates the user's `notifyOnStatusChange` preference in the database, and then redirects to the success page.

Fixes #85

---
*PR created automatically by Jules for task [17322886785314971978](https://jules.google.com/task/17322886785314971978) started by @guillot-jpm*